### PR TITLE
Fixed images in Markdown pages from breaking responsiveness

### DIFF
--- a/Home/_layouts/default-md.html
+++ b/Home/_layouts/default-md.html
@@ -8,6 +8,7 @@ layout: base
 <![endif]-->
 
 {% include header.html %}
+<link rel="stylesheet" href="/css/md.css">
 <div class="container" id="main-content" style="padding-bottom: 32px">
     <div class="col-sm-12 col-md-8 col-md-offset-2">
         {{ content }}

--- a/Home/css/about/czestochowa.css
+++ b/Home/css/about/czestochowa.css
@@ -11,10 +11,3 @@ body {
 h1 {
     color: gold;
 }
-
-#main-content img {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 500px;
-}

--- a/Home/css/md.css
+++ b/Home/css/md.css
@@ -1,0 +1,6 @@
+#main-content img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}


### PR DESCRIPTION
The fix was applied by adding a Markdown-only CSS file that fixes images under main-content.
This fix applies to both Czestochowa and Year of the Poor feature pages.
