### PR TITLE
Copyright year update + Netlify attribution

### DIFF
--- a/Home/_includes/footer.html
+++ b/Home/_includes/footer.html
@@ -1,8 +1,8 @@
 <footer class="site-footer">
     <!-- Footer -->
     <div class="container-fluid" id="footer" style="text-align: center">
-    Copyright © 2015 Transfiguration of Christ Parish.
-        <br />Source available at <a href="https://www.github.com/jerieljan/ourtransfi">GitHub</a>, made with Jekyll, built with Travis.
+    Copyright © 2019 Transfiguration of Christ Parish.
+        <br />Source available at <a href="https://www.github.com/jerieljan/ourtransfi">GitHub</a>, made with Jekyll, built with Netlify.
         <br /><a href="https://docs.google.com/forms/d/1bcRaDoSqWHgCidTGAnh9fdaTDqOHCbsFS7OrBlSUNXE/viewform?usp=send_form">Site Feedback?</a>
     </div>
 


### PR DESCRIPTION
Removed the old Travis attribution that’s no longer in use, and Copyright 2019.